### PR TITLE
flog added and haml-lint rubocop error misplaced fix

### DIFF
--- a/checkout_fenrir.yml
+++ b/checkout_fenrir.yml
@@ -37,12 +37,18 @@
 # install extra global gems
 - name: install bundler
   command: rvm @global do gem install bundler
+
 - name: install rubocop
-  command: rvm @global do gem install haml_lint
+  command: rvm @global do gem install rubocop
+
 - name: install brakeman
   command: rvm @global do gem install brakeman
+
 - name: install haml-lint
   command: rvm @global do gem install haml_lint
+
+- name: install flog
+  command: rvm @global do gem install flog
 # install npm
 - name: install npm
   sudo: true


### PR DESCRIPTION
Added flog gem to check for complexity in ruby. Fixed haml-lint double install when it should have been rubocop installing